### PR TITLE
Refactor the configuration code and ask for the token the first time you start

### DIFF
--- a/cli/yml.go
+++ b/cli/yml.go
@@ -6,32 +6,59 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-func CreateConfigDirectory() {
-	os.MkdirAll(os.Getenv("HOME")+"/.config/cligpt/", 0755)
-	if _, err := os.Stat(os.Getenv("HOME") + "/.config/cligpt/cligpt.yml"); os.IsNotExist(err) {
-		file, err := os.Create(os.Getenv("HOME") + "/.config/cligpt/cligpt.yml")
-		if err != nil {
-			panic(err)
-		}
-		defer file.Close()
-		config := `auth: token
-model: text-davinci-003
-max_tokens: 256`
-		file.WriteString(config)
-	}
+var defaultConfigYml = map[string]string{
+	"auth":       "token",
+	"model":      "text-davinci-003",
+	"max_tokens": "256",
 }
 
-func ReadFromYml(variable string) string {
-	file, err := os.Open(os.Getenv("HOME") + "/.config/cligpt/cligpt.yml")
+var configFolderName = "/cligpt/"
+var configFileName = "cligpt.yml"
+
+func getConfigDir() (string, error) {
+	var userConfigDir, err = os.UserConfigDir()
+	return userConfigDir + configFolderName, err
+}
+
+func CreateConfigDirectory() error {
+	var err error
+	var cligptConfigDir string
+	if cligptConfigDir, err = getConfigDir(); err != nil {
+		return err
+	}
+	var cligptConfigFile = cligptConfigDir + configFileName
+
+	os.MkdirAll(cligptConfigDir, 0755)
+
+	if _, err := os.Stat(cligptConfigFile); os.IsExist(err) {
+		return err
+	}
+	file, err := os.Create(cligptConfigFile)
 	if err != nil {
-		panic(err)
+		return err
+	}
+	defer file.Close()
+
+	var bffYml = yaml.NewEncoder(file)
+	defer bffYml.Close()
+	return bffYml.Encode(defaultConfigYml)
+}
+
+func ReadYml() (map[string]string, error) {
+	var err error
+	var cligptConfigDir string
+	if cligptConfigDir, err = getConfigDir(); err != nil {
+		return nil, err
+	}
+	var cligptConfigFile = cligptConfigDir + configFileName
+
+	file, err := os.Open(cligptConfigFile)
+	if err != nil {
+		return nil, err
 	}
 	defer file.Close()
 	var config map[string]string
 	decoder := yaml.NewDecoder(file)
 	err = decoder.Decode(&config)
-	if err != nil {
-		panic(err)
-	}
-	return string(config[variable])
+	return config, err
 }


### PR DESCRIPTION
* Add functionality to ask for the user's token the first time they start
* Now by default the configuration is saved in the user configuration folder, this way in windows the files are also kept where they should be.
* Add some error validations
* remove unnecessary io reads

-- I'm pretty sure things in main.go can be improved but I'll do that a bit later. I'm currently excited to see if you accept my changes

