### PR TITLE
increase default max tokens limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Et magna in mundo fata sequamur.
 ```haskell
 auth: token
 model: text-davinci-003
-max_tokens: 256
+max_tokens: 2000
 ```
 
 <h1>Building</h1>

--- a/cli/yml.go
+++ b/cli/yml.go
@@ -10,7 +10,7 @@ import (
 
 var defaultConfigYml = map[string]string{
 	"model":      "text-davinci-003",
-	"max_tokens": "256",
+	"max_tokens": "2000",
 }
 
 var configFolderName = "/cligpt/"


### PR DESCRIPTION
increases the maximum amount of tokens allowed for the `text-davinci-003` model from 256 to 2000. this will allow for larger tasks to be completed in the same amount of time.

this commit makes the following changes:

- updates `max_tokens` in `defaultconfigyml` from `256` to `2000`

the change is necessary in order to allow for larger tasks to be completed in the same amount of time. increasing the `max_tokens` limit from `256` to `2000` will allow for a more efficient workflow.

this change will have a positive impact on the performance of the `text-davinci-003` model. by increasing the `max_tokens` limit, users will be able to complete more tasks in the same amount of time.