### PR TITLE
update build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ max_tokens: 256
 
 - Build the cli.
 
-`./build.sh`
+```bash
+go build
+```
 
 ![image](https://user-images.githubusercontent.com/69026987/209194859-a2456a7d-796f-47e0-8a8e-062848e2cbaf.png)


### PR DESCRIPTION
updates the build instructions in the readme.md file. the previous instructions to run `./build.sh` have been replaced with the command `go build` once there isn't such script available.

```diff
diff --git a/readme.md b/readme.md
index ba9e6ddd5686..944d3eb97a6b 100644
--- a/readme.md
+++ b/readme.md
@@ -47,6 +47,8 @@ max_tokens: 256

 - build the cli.

 -`./build.sh`
+```bash
+go build
+```

![image](https://user-images.githubusercontent.com/69026987/209194859-a2456a7d-796f-47e0-8a8e-062848e2cbaf.png)
```